### PR TITLE
create md5 from sec group rule description in order to allow multiple…

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,8 +192,8 @@ Available targets:
 
 | Name |
 |------|
-| [aws_security_group](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/security_group) |
 | [aws_security_group](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/data-sources/security_group) |
+| [aws_security_group](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/security_group) |
 | [aws_security_group_rule](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/security_group_rule) |
 
 ## Inputs

--- a/README.md
+++ b/README.md
@@ -182,6 +182,20 @@ Available targets:
 |------|---------|
 | aws | >= 2.0 |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| this | cloudposse/label/null | 0.24.1 |
+
+## Resources
+
+| Name |
+|------|
+| [aws_security_group](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/security_group) |
+| [aws_security_group](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/data-sources/security_group) |
+| [aws_security_group_rule](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/security_group_rule) |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -215,7 +229,6 @@ Available targets:
 | arn | The Security Group ARN |
 | id | The Security Group ID |
 | name | The Security Group Name |
-
 <!-- markdownlint-restore -->
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -22,8 +22,8 @@
 
 | Name |
 |------|
-| [aws_security_group](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/security_group) |
 | [aws_security_group](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/data-sources/security_group) |
+| [aws_security_group](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/security_group) |
 | [aws_security_group_rule](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/security_group_rule) |
 
 ## Inputs

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -12,6 +12,20 @@
 |------|---------|
 | aws | >= 2.0 |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| this | cloudposse/label/null | 0.24.1 |
+
+## Resources
+
+| Name |
+|------|
+| [aws_security_group](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/security_group) |
+| [aws_security_group](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/data-sources/security_group) |
+| [aws_security_group_rule](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/security_group_rule) |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -45,5 +59,4 @@
 | arn | The Security Group ARN |
 | id | The Security Group ID |
 | name | The Security Group Name |
-
 <!-- markdownlint-restore -->

--- a/main.tf
+++ b/main.tf
@@ -18,7 +18,7 @@ locals {
       lookup(rule, "security_group_id", null) == null ? "no_ssg" : "ssg",
       lookup(rule, "prefix_list_ids", null) == null ? "no_pli" : "pli",
       lookup(rule, "self", null) == null ? "no_self" : "self",
-      lookup(rule, "description", null) == null ? "no_desc" : "desc"
+      lookup(rule, "description", null) == null ? "no_desc" : md5(rule.description)
     ) => rule
   } : {}
 }


### PR DESCRIPTION
… rules with the same port and different descriptions.

## what
* This PR generates the md5 hash from the security group rule description when creating the rule map keys.


## why
* This change prevents key map duplication when generating the security group rule map and there are rules with the same port and different descriptions. Example below:

**main.tf**
```
module "security_groups" 
  source = "github.com/cloudposse/terraform-aws-security-group"

  name        =  "sg_name"
  vpc_id      = "vpc-0000111122223333"
  rules       = [
        {
          type        = "ingress"
          from_port   = 22
          to_port     = 22
          protocol    = "tcp"
          cidr_blocks = "10.10.0.0/16"
          description = "Allow ssh from main office"
        },
        {
          type        = "ingress"
          from_port   = 22
          to_port     = 22
          protocol    = "tcp"
          cidr_blocks = "192.168.0.0/24"
          description = "Allow ssh from management VPC"
        },
        {
          type        = "egress"
          from_port   = 0
          to_port     = 65535
          protocol    = "all"
          cidr_blocks = ["0.0.0.0/0"]
          description = "Allow all outbound"
        }
      ]
  description = "sg_descrition"
}
```
**ERROR**
```
Error: Duplicate object key

  on .terraform/modules/security_groups/main.tf line 11, in locals:
   9:   rules = module.this.enabled && var.rules != null ? {
  10:     for rule in flatten(distinct(var.rules)) :
  11:     format("%s-%s-%s-%s-%s-%s-%s-%s-%s-%s",
  12:       rule.type,
  13:       rule.protocol,
  14:       rule.from_port,
  15:       rule.to_port,
  16:       lookup(rule, "cidr_blocks", null) == null ? "no_ipv4" : "ipv4",
  17:       lookup(rule, "ipv6_cidr_blocks", null) == null ? "no_ipv6" : "ipv6",
  18:       lookup(rule, "security_group_id", null) == null ? "no_ssg" : "ssg",
  19:       lookup(rule, "prefix_list_ids", null) == null ? "no_pli" : "pli",
  20:       lookup(rule, "self", null) == null ? "no_self" : "self",
  21:       lookup(rule, "description", null) == null ? "no_desc" : "desc"
  22:     ) => rule
  23:   } : {}
    |----------------
    | rule.from_port is 22
    | rule.protocol is "tcp"
    | rule.to_port is 22
    | rule.type is "ingress"

Two different items produced the key
"ingress-tcp-22-22-ipv4-no_ipv6-no_ssg-no_pli-no_self-desc" in this 'for'
expression. If duplicates are expected, use the ellipsis (...) after the value
expression to enable grouping by key.
```

## references


