### PR TITLE
Add resource outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,10 +259,10 @@ Available targets:
 | Name | Description |
 |------|-------------|
 | <a name="output_arn"></a> [arn](#output\_arn) | The Security Group ARN |
-| <a name="output_aws_security_group"></a> [aws\_security\_group](#output\_aws\_security\_group) | All of the `aws_security_group` resource outputs |
-| <a name="output_aws_security_group_rule"></a> [aws\_security\_group\_rule](#output\_aws\_security\_group\_rule) | All of the `aws_security_group_rule` resource outputs |
 | <a name="output_id"></a> [id](#output\_id) | The Security Group ID |
+| <a name="output_metadata"></a> [metadata](#output\_metadata) | All of the `aws_security_group` resource outputs |
 | <a name="output_name"></a> [name](#output\_name) | The Security Group Name |
+| <a name="output_rules"></a> [rules](#output\_rules) | All of the `aws_security_group_rule` resource outputs |
 <!-- markdownlint-restore -->
 
 

--- a/README.md
+++ b/README.md
@@ -259,6 +259,8 @@ Available targets:
 | Name | Description |
 |------|-------------|
 | <a name="output_arn"></a> [arn](#output\_arn) | The Security Group ARN |
+| <a name="output_aws_security_group"></a> [aws\_security\_group](#output\_aws\_security\_group) | All of the `aws_security_group` resource outputs |
+| <a name="output_aws_security_group_rule"></a> [aws\_security\_group\_rule](#output\_aws\_security\_group\_rule) | All of the `aws_security_group_rule` resource outputs |
 | <a name="output_id"></a> [id](#output\_id) | The Security Group ID |
 | <a name="output_name"></a> [name](#output\_name) | The Security Group Name |
 <!-- markdownlint-restore -->

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -57,6 +57,8 @@
 | Name | Description |
 |------|-------------|
 | <a name="output_arn"></a> [arn](#output\_arn) | The Security Group ARN |
+| <a name="output_aws_security_group"></a> [aws\_security\_group](#output\_aws\_security\_group) | All of the `aws_security_group` resource outputs |
+| <a name="output_aws_security_group_rule"></a> [aws\_security\_group\_rule](#output\_aws\_security\_group\_rule) | All of the `aws_security_group_rule` resource outputs |
 | <a name="output_id"></a> [id](#output\_id) | The Security Group ID |
 | <a name="output_name"></a> [name](#output\_name) | The Security Group Name |
 <!-- markdownlint-restore -->

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -57,8 +57,8 @@
 | Name | Description |
 |------|-------------|
 | <a name="output_arn"></a> [arn](#output\_arn) | The Security Group ARN |
-| <a name="output_aws_security_group"></a> [aws\_security\_group](#output\_aws\_security\_group) | All of the `aws_security_group` resource outputs |
-| <a name="output_aws_security_group_rule"></a> [aws\_security\_group\_rule](#output\_aws\_security\_group\_rule) | All of the `aws_security_group_rule` resource outputs |
 | <a name="output_id"></a> [id](#output\_id) | The Security Group ID |
+| <a name="output_metadata"></a> [metadata](#output\_metadata) | All of the `aws_security_group` resource outputs |
 | <a name="output_name"></a> [name](#output\_name) | The Security Group Name |
+| <a name="output_rules"></a> [rules](#output\_rules) | All of the `aws_security_group_rule` resource outputs |
 <!-- markdownlint-restore -->

--- a/outputs.tf
+++ b/outputs.tf
@@ -13,12 +13,12 @@ output "name" {
   value       = try(local.name, null)
 }
 
-output "aws_security_group" {
+output "metadata" {
   description = "All of the `aws_security_group` resource outputs"
   value       = try(aws_security_group.default, null)
 }
 
-output "aws_security_group_rule" {
+output "rules" {
   description = "All of the `aws_security_group_rule` resource outputs"
   value       = try(aws_security_group_rule.default, null)
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -15,10 +15,10 @@ output "name" {
 
 output "aws_security_group" {
   description = "All of the `aws_security_group` resource outputs"
-  value       = aws_security_group.default
+  value       = try(aws_security_group.default, null)
 }
 
 output "aws_security_group_rule" {
   description = "All of the `aws_security_group_rule` resource outputs"
-  value       = aws_security_group_rule.default
+  value       = try(aws_security_group_rule.default, null)
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -12,3 +12,13 @@ output "name" {
   description = "The Security Group Name"
   value       = try(local.name, null)
 }
+
+output "aws_security_group" {
+  description = "All of the `aws_security_group` resource outputs"
+  value       = aws_security_group.default
+}
+
+output "aws_security_group_rule" {
+  description = "All of the `aws_security_group_rule` resource outputs"
+  value       = aws_security_group_rule.default
+}


### PR DESCRIPTION
## what
* Add outputs for `aws_security_group` and `aws_security_group_rule` resources

## why
* If the aws provider ever increased the number of outputs for either of the above resources, this module would be flexible enough to automatically output those additional outputs without having to update this module again
* For example, `tags_all` output is missing for the `aws_security_group` and `id` is missing for `aws_security_group_rule`

## references
* https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group
* https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule

