### PR TITLE
Default cidr blocks to empty list

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -146,8 +146,8 @@ resource "aws_security_group_rule" "keyed" {
   to_port          = each.value.to_port
   protocol         = each.value.protocol
   description      = each.value.description
-  cidr_blocks      = length(each.value.cidr_blocks) == 0 ? null : each.value.cidr_blocks
-  ipv6_cidr_blocks = length(each.value.ipv6_cidr_blocks) == 0 ? null : each.value.ipv6_cidr_blocks
+  cidr_blocks      = length(each.value.cidr_blocks) == 0 ? [] : each.value.cidr_blocks
+  ipv6_cidr_blocks = length(each.value.ipv6_cidr_blocks) == 0 ? [] : each.value.ipv6_cidr_blocks
   prefix_list_ids  = length(each.value.prefix_list_ids) == 0 ? [] : each.value.prefix_list_ids
   self             = each.value.self
 


### PR DESCRIPTION
## what
* Default cidr blocks to empty list

## why
* Otherwise on each plan, this is shown for each sg rule

```hcl
  # module.msk_cluster.module.broker_security_group.aws_security_group_rule.keyed["_m[0]#tls#sg#0"] has been changed
  ~ resource "aws_security_group_rule" "keyed" {
      + cidr_blocks              = []
        id                       = "sgrule-snip"
      + ipv6_cidr_blocks         = []
        # (9 unchanged attributes hidden)
    }
```

## references
N/A

