### PR TITLE
Rename the exported `security_group_inputs.tf` file to `security-group-inputs.tf`

### DIFF
--- a/.github/auto-release.yml
+++ b/.github/auto-release.yml
@@ -47,7 +47,7 @@ template: |
 
 replacers:
 # Remove irrelevant information from Renovate bot
-- search: '/(?<=---\s+)+^#.*(Renovate configuration|Configuration)(?:.|\n)*?This PR has been generated .*/gm'
+- search: '/(?<=---\s)\s*^#.*(Renovate configuration|Configuration)(?:.|\n)*?This PR has been generated .*/gm'
   replace: ''
 # Remove Renovate bot banner image
 - search: '/\[!\[[^\]]*Renovate\][^\]]*\](\([^)]*\))?\s*\n+/gm'

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2020 Cloud Posse, LLC
+   Copyright 2020-2022 Cloud Posse, LLC
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2020-2022 Cloud Posse, LLC
+   Copyright 2021-2022 Cloud Posse, LLC
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -448,11 +448,7 @@ Available targets:
 |------|------|
 | [aws_security_group.cbd](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
-| [aws_security_group_rule.keyed_cidr_blocks](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.keyed_ipv6_cidr_blocks](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.keyed_prefix_list_ids](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.keyed_self](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.keyed_source_security_group_id](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.keyed](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 
 ## Inputs
 

--- a/README.md
+++ b/README.md
@@ -592,7 +592,7 @@ In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
 
 ## Copyrights
 
-Copyright © 2021-2021 [Cloud Posse, LLC](https://cloudposse.com)
+Copyright © 2021-2022-2021 [Cloud Posse, LLC](https://cloudposse.com)
 
 
 
@@ -652,14 +652,18 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
 ### Contributors
 
 <!-- markdownlint-disable -->
-|  [![Erik Osterman][osterman_avatar]][osterman_homepage]<br/>[Erik Osterman][osterman_homepage] | [![Vladimir][SweetOps_avatar]][SweetOps_homepage]<br/>[Vladimir][SweetOps_homepage] |
-|---|---|
+|  [![Erik Osterman][osterman_avatar]][osterman_homepage]<br/>[Erik Osterman][osterman_homepage] | [![Vladimir][SweetOps_avatar]][SweetOps_homepage]<br/>[Vladimir][SweetOps_homepage] | [![RB][nitrocode_avatar]][nitrocode_homepage]<br/>[RB][nitrocode_homepage] | [![Andriy Knysh][aknysh_avatar]][aknysh_homepage]<br/>[Andriy Knysh][aknysh_homepage] |
+|---|---|---|---|
 <!-- markdownlint-restore -->
 
   [osterman_homepage]: https://github.com/osterman
   [osterman_avatar]: https://img.cloudposse.com/150x150/https://github.com/osterman.png
   [SweetOps_homepage]: https://github.com/SweetOps
   [SweetOps_avatar]: https://img.cloudposse.com/150x150/https://github.com/SweetOps.png
+  [nitrocode_homepage]: https://github.com/nitrocode
+  [nitrocode_avatar]: https://img.cloudposse.com/150x150/https://github.com/nitrocode.png
+  [aknysh_homepage]: https://github.com/aknysh
+  [aknysh_avatar]: https://img.cloudposse.com/150x150/https://github.com/aknysh.png
 
 [![README Footer][readme_footer_img]][readme_footer_link]
 [![Beacon][beacon]][website]

--- a/README.md
+++ b/README.md
@@ -448,7 +448,11 @@ Available targets:
 |------|------|
 | [aws_security_group.cbd](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
-| [aws_security_group_rule.keyed](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.keyed_cidr_blocks](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.keyed_ipv6_cidr_blocks](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.keyed_prefix_list_ids](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.keyed_self](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.keyed_source_security_group_id](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 
 ## Inputs
 

--- a/README.md
+++ b/README.md
@@ -592,7 +592,7 @@ In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
 
 ## Copyrights
 
-Copyright © 2021-2022-2021 [Cloud Posse, LLC](https://cloudposse.com)
+Copyright © 2021-2021 [Cloud Posse, LLC](https://cloudposse.com)
 
 
 

--- a/README.yaml
+++ b/README.yaml
@@ -24,7 +24,7 @@ license: "APACHE2"
 copyrights:
   - name: "Cloud Posse, LLC"
     url: "https://cloudposse.com"
-    year: "2021-2022"
+    year: "2021"
 
 # Canonical GitHub repo
 github_repo: cloudposse/terraform-aws-security-group

--- a/README.yaml
+++ b/README.yaml
@@ -24,7 +24,7 @@ license: "APACHE2"
 copyrights:
   - name: "Cloud Posse, LLC"
     url: "https://cloudposse.com"
-    year: "2021"
+    year: "2021-2022"
 
 # Canonical GitHub repo
 github_repo: cloudposse/terraform-aws-security-group
@@ -389,3 +389,7 @@ contributors:
     github: "osterman"
   - name: "Vladimir"
     github: "SweetOps"
+  - name: "RB"
+    github: "nitrocode"
+  - name: "Andriy Knysh"
+    github: "aknysh"

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -24,11 +24,7 @@
 |------|------|
 | [aws_security_group.cbd](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
-| [aws_security_group_rule.keyed_cidr_blocks](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.keyed_ipv6_cidr_blocks](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.keyed_prefix_list_ids](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.keyed_self](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.keyed_source_security_group_id](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.keyed](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 
 ## Inputs
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -24,7 +24,11 @@
 |------|------|
 | [aws_security_group.cbd](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
-| [aws_security_group_rule.keyed](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.keyed_cidr_blocks](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.keyed_ipv6_cidr_blocks](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.keyed_prefix_list_ids](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.keyed_self](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.keyed_source_security_group_id](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 
 ## Inputs
 

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -47,3 +47,8 @@ output "disabled_sg_name" {
   description = "The disabled Security Group Name (should be empty)"
   value       = module.disabled_security_group.name == null ? "" : module.disabled_security_group.name
 }
+
+output "rules_terraform_ids" {
+  description = "List of Terraform IDs of created `security_group_rule` resources"
+  value       = module.new_security_group.rules_terraform_ids
+}

--- a/exports/security-group-inputs.tf
+++ b/exports/security-group-inputs.tf
@@ -1,6 +1,6 @@
-# security_group_inputs Version: 2
+# security-group-inputs Version: 2
 #
-# Copy this file from https://github.com/cloudposse/terraform-aws-security-group/blob/master/exports/security_group_inputs.tf
+# Copy this file from https://github.com/cloudposse/terraform-aws-security-group/blob/master/exports/security-group-inputs.tf
 # and EDIT IT TO SUIT YOUR PROJECT. Update the version number above if you update this file from a later version.
 # Unlike null-label context.tf, this file cannot be automatically updated
 # because of the tight integration with the module using it.

--- a/main.tf
+++ b/main.tf
@@ -139,7 +139,7 @@ resource "aws_security_group" "cbd" {
 }
 
 resource "aws_security_group_rule" "keyed_cidr_blocks" {
-  for_each = { for k, v in local.keyed_resource_rules : k => v if lookup(v, "cidr_blocks", null) != null }
+  for_each = { for k, v in local.keyed_resource_rules : k => v if try(v.cidr_blocks, null) != null }
 
   security_group_id = local.security_group_id
 
@@ -159,7 +159,7 @@ resource "aws_security_group_rule" "keyed_cidr_blocks" {
 }
 
 resource "aws_security_group_rule" "keyed_ipv6_cidr_blocks" {
-  for_each = { for k, v in local.keyed_resource_rules : k => v if lookup(v, "ipv6_cidr_blocks", null) != null }
+  for_each = { for k, v in local.keyed_resource_rules : k => v if try(v.ipv6_cidr_blocks, null) != null }
 
   security_group_id = local.security_group_id
 
@@ -179,7 +179,7 @@ resource "aws_security_group_rule" "keyed_ipv6_cidr_blocks" {
 }
 
 resource "aws_security_group_rule" "keyed_prefix_list_ids" {
-  for_each = { for k, v in local.keyed_resource_rules : k => v if lookup(v, "prefix_list_ids", null) != null }
+  for_each = { for k, v in local.keyed_resource_rules : k => v if try(v.prefix_list_ids, null) != null }
 
   security_group_id = local.security_group_id
 
@@ -199,7 +199,7 @@ resource "aws_security_group_rule" "keyed_prefix_list_ids" {
 }
 
 resource "aws_security_group_rule" "keyed_self" {
-  for_each = { for k, v in local.keyed_resource_rules : k => v if lookup(v, "self", true) == true }
+  for_each = { for k, v in local.keyed_resource_rules : k => v if try(v.self, false) == true }
 
   security_group_id = local.security_group_id
 
@@ -219,7 +219,7 @@ resource "aws_security_group_rule" "keyed_self" {
 }
 
 resource "aws_security_group_rule" "keyed_source_security_group_id" {
-  for_each = { for k, v in local.keyed_resource_rules : k => v if lookup(v, "source_security_group_id", null) != null }
+  for_each = { for k, v in local.keyed_resource_rules : k => v if try(v.source_security_group_id, null) != null }
 
   security_group_id = local.security_group_id
 

--- a/main.tf
+++ b/main.tf
@@ -139,7 +139,7 @@ resource "aws_security_group" "cbd" {
 }
 
 resource "aws_security_group_rule" "keyed_cidr_blocks" {
-  for_each = { for r in local.all_resource_rules : r.key => r if try(length(r.cidr_blocks), 0) > 0 }
+  for_each = local.keyed_resource_rules_cidr_blocks
 
   security_group_id = local.security_group_id
 
@@ -159,7 +159,7 @@ resource "aws_security_group_rule" "keyed_cidr_blocks" {
 }
 
 resource "aws_security_group_rule" "keyed_ipv6_cidr_blocks" {
-  for_each = { for r in local.all_resource_rules : r.key => r if try(length(r.ipv6_cidr_blocks), 0) > 0 }
+  for_each = local.keyed_resource_rules_ipv6_cidr_blocks
 
   security_group_id = local.security_group_id
 
@@ -179,7 +179,7 @@ resource "aws_security_group_rule" "keyed_ipv6_cidr_blocks" {
 }
 
 resource "aws_security_group_rule" "keyed_prefix_list_ids" {
-  for_each = { for r in local.all_resource_rules : r.key => r if try(length(r.prefix_list_ids), 0) > 0 }
+  for_each = local.keyed_resource_rules_prefix_list_ids
 
   security_group_id = local.security_group_id
 
@@ -199,7 +199,7 @@ resource "aws_security_group_rule" "keyed_prefix_list_ids" {
 }
 
 resource "aws_security_group_rule" "keyed_self" {
-  for_each = { for r in local.all_resource_rules : r.key => r if try(r.self, false) == true }
+  for_each = local.keyed_resource_rules_self
 
   security_group_id = local.security_group_id
 
@@ -219,7 +219,7 @@ resource "aws_security_group_rule" "keyed_self" {
 }
 
 resource "aws_security_group_rule" "keyed_source_security_group_id" {
-  for_each = { for r in local.all_resource_rules : r.key => r if try(length(r.source_security_group_id), 0) > 0 }
+  for_each = local.keyed_resource_rules_source_security_group_id
 
   security_group_id = local.security_group_id
 

--- a/main.tf
+++ b/main.tf
@@ -161,7 +161,3 @@ resource "aws_security_group_rule" "keyed" {
     create_before_destroy = true
   }
 }
-
-locals {
-  rules_terraform_ids = values(aws_security_group_rule.keyed).*.id
-}

--- a/main.tf
+++ b/main.tf
@@ -139,7 +139,7 @@ resource "aws_security_group" "cbd" {
 }
 
 resource "aws_security_group_rule" "keyed_cidr_blocks" {
-  for_each = { for k, v in local.keyed_resource_rules : k => v if length(lookup(v, "cidr_blocks", [])) > 0 }
+  for_each = { for k, v in local.keyed_resource_rules : k => v if lookup(v, "cidr_blocks", null) != null }
 
   security_group_id = local.security_group_id
 
@@ -159,7 +159,7 @@ resource "aws_security_group_rule" "keyed_cidr_blocks" {
 }
 
 resource "aws_security_group_rule" "keyed_ipv6_cidr_blocks" {
-  for_each = { for k, v in local.keyed_resource_rules : k => v if length(lookup(v, "ipv6_cidr_blocks", [])) > 0 }
+  for_each = { for k, v in local.keyed_resource_rules : k => v if lookup(v, "ipv6_cidr_blocks", null) != null }
 
   security_group_id = local.security_group_id
 
@@ -179,7 +179,7 @@ resource "aws_security_group_rule" "keyed_ipv6_cidr_blocks" {
 }
 
 resource "aws_security_group_rule" "keyed_prefix_list_ids" {
-  for_each = { for k, v in local.keyed_resource_rules : k => v if length(lookup(v, "prefix_list_ids", [])) > 0 }
+  for_each = { for k, v in local.keyed_resource_rules : k => v if lookup(v, "prefix_list_ids", null) != null }
 
   security_group_id = local.security_group_id
 
@@ -219,7 +219,7 @@ resource "aws_security_group_rule" "keyed_self" {
 }
 
 resource "aws_security_group_rule" "keyed_source_security_group_id" {
-  for_each = { for k, v in local.keyed_resource_rules : k => v if length(lookup(v, "source_security_group_id", "")) > 0 }
+  for_each = { for k, v in local.keyed_resource_rules : k => v if lookup(v, "source_security_group_id", null) != null }
 
   security_group_id = local.security_group_id
 

--- a/main.tf
+++ b/main.tf
@@ -138,20 +138,97 @@ resource "aws_security_group" "cbd" {
 
 }
 
-resource "aws_security_group_rule" "keyed" {
-  for_each = local.keyed_resource_rules
+resource "aws_security_group_rule" "keyed_cidr_blocks" {
+  for_each = { for k, v in local.keyed_resource_rules : k => v if length(lookup(v, "cidr_blocks", [])) > 0 }
 
-  type             = each.value.type
-  from_port        = each.value.from_port
-  to_port          = each.value.to_port
-  protocol         = each.value.protocol
-  description      = each.value.description
-  cidr_blocks      = length(each.value.cidr_blocks) == 0 ? [] : each.value.cidr_blocks
-  ipv6_cidr_blocks = length(each.value.ipv6_cidr_blocks) == 0 ? [] : each.value.ipv6_cidr_blocks
-  prefix_list_ids  = length(each.value.prefix_list_ids) == 0 ? [] : each.value.prefix_list_ids
-  self             = each.value.self
+  security_group_id = local.security_group_id
 
-  security_group_id        = local.security_group_id
+  type        = each.value.type
+  from_port   = each.value.from_port
+  to_port     = each.value.to_port
+  protocol    = each.value.protocol
+  description = each.value.description
+
+  cidr_blocks = each.value.cidr_blocks
+
+  depends_on = [aws_security_group.cbd, aws_security_group.default]
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_security_group_rule" "keyed_ipv6_cidr_blocks" {
+  for_each = { for k, v in local.keyed_resource_rules : k => v if length(lookup(v, "ipv6_cidr_blocks", [])) > 0 }
+
+  security_group_id = local.security_group_id
+
+  type        = each.value.type
+  from_port   = each.value.from_port
+  to_port     = each.value.to_port
+  protocol    = each.value.protocol
+  description = each.value.description
+
+  ipv6_cidr_blocks = each.value.ipv6_cidr_blocks
+
+  depends_on = [aws_security_group.cbd, aws_security_group.default]
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_security_group_rule" "keyed_prefix_list_ids" {
+  for_each = { for k, v in local.keyed_resource_rules : k => v if length(lookup(v, "prefix_list_ids", [])) > 0 }
+
+  security_group_id = local.security_group_id
+
+  type        = each.value.type
+  from_port   = each.value.from_port
+  to_port     = each.value.to_port
+  protocol    = each.value.protocol
+  description = each.value.description
+
+  prefix_list_ids = each.value.prefix_list_ids
+
+  depends_on = [aws_security_group.cbd, aws_security_group.default]
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_security_group_rule" "keyed_self" {
+  for_each = { for k, v in local.keyed_resource_rules : k => v if lookup(v, "self", true) == true }
+
+  security_group_id = local.security_group_id
+
+  type        = each.value.type
+  from_port   = each.value.from_port
+  to_port     = each.value.to_port
+  protocol    = each.value.protocol
+  description = each.value.description
+
+  self = each.value.self
+
+  depends_on = [aws_security_group.cbd, aws_security_group.default]
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_security_group_rule" "keyed_source_security_group_id" {
+  for_each = { for k, v in local.keyed_resource_rules : k => v if length(lookup(v, "source_security_group_id", "")) > 0 }
+
+  security_group_id = local.security_group_id
+
+  type        = each.value.type
+  from_port   = each.value.from_port
+  to_port     = each.value.to_port
+  protocol    = each.value.protocol
+  description = each.value.description
+
   source_security_group_id = each.value.source_security_group_id
 
   depends_on = [aws_security_group.cbd, aws_security_group.default]
@@ -159,4 +236,14 @@ resource "aws_security_group_rule" "keyed" {
   lifecycle {
     create_before_destroy = true
   }
+}
+
+locals {
+  rules_terraform_ids = concat(
+    values(aws_security_group_rule.keyed_cidr_blocks)[*].id,
+    values(aws_security_group_rule.keyed_ipv6_cidr_blocks)[*].id,
+    values(aws_security_group_rule.keyed_prefix_list_ids)[*].id,
+    values(aws_security_group_rule.keyed_self)[*].id,
+    values(aws_security_group_rule.keyed_source_security_group_id)[*].id
+  )
 }

--- a/main.tf
+++ b/main.tf
@@ -138,8 +138,8 @@ resource "aws_security_group" "cbd" {
 
 }
 
-resource "aws_security_group_rule" "keyed_cidr_blocks" {
-  for_each = local.keyed_resource_rules_cidr_blocks
+resource "aws_security_group_rule" "keyed" {
+  for_each = local.keyed_resource_rules
 
   security_group_id = local.security_group_id
 
@@ -149,86 +149,10 @@ resource "aws_security_group_rule" "keyed_cidr_blocks" {
   protocol    = each.value.protocol
   description = each.value.description
 
-  cidr_blocks = each.value.cidr_blocks
-
-  depends_on = [aws_security_group.cbd, aws_security_group.default]
-
-  lifecycle {
-    create_before_destroy = true
-  }
-}
-
-resource "aws_security_group_rule" "keyed_ipv6_cidr_blocks" {
-  for_each = local.keyed_resource_rules_ipv6_cidr_blocks
-
-  security_group_id = local.security_group_id
-
-  type        = each.value.type
-  from_port   = each.value.from_port
-  to_port     = each.value.to_port
-  protocol    = each.value.protocol
-  description = each.value.description
-
-  ipv6_cidr_blocks = each.value.ipv6_cidr_blocks
-
-  depends_on = [aws_security_group.cbd, aws_security_group.default]
-
-  lifecycle {
-    create_before_destroy = true
-  }
-}
-
-resource "aws_security_group_rule" "keyed_prefix_list_ids" {
-  for_each = local.keyed_resource_rules_prefix_list_ids
-
-  security_group_id = local.security_group_id
-
-  type        = each.value.type
-  from_port   = each.value.from_port
-  to_port     = each.value.to_port
-  protocol    = each.value.protocol
-  description = each.value.description
-
-  prefix_list_ids = each.value.prefix_list_ids
-
-  depends_on = [aws_security_group.cbd, aws_security_group.default]
-
-  lifecycle {
-    create_before_destroy = true
-  }
-}
-
-resource "aws_security_group_rule" "keyed_self" {
-  for_each = local.keyed_resource_rules_self
-
-  security_group_id = local.security_group_id
-
-  type        = each.value.type
-  from_port   = each.value.from_port
-  to_port     = each.value.to_port
-  protocol    = each.value.protocol
-  description = each.value.description
-
-  self = each.value.self
-
-  depends_on = [aws_security_group.cbd, aws_security_group.default]
-
-  lifecycle {
-    create_before_destroy = true
-  }
-}
-
-resource "aws_security_group_rule" "keyed_source_security_group_id" {
-  for_each = local.keyed_resource_rules_source_security_group_id
-
-  security_group_id = local.security_group_id
-
-  type        = each.value.type
-  from_port   = each.value.from_port
-  to_port     = each.value.to_port
-  protocol    = each.value.protocol
-  description = each.value.description
-
+  cidr_blocks              = length(each.value.cidr_blocks) == 0 ? null : each.value.cidr_blocks
+  ipv6_cidr_blocks         = length(each.value.ipv6_cidr_blocks) == 0 ? null : each.value.ipv6_cidr_blocks
+  prefix_list_ids          = length(each.value.prefix_list_ids) == 0 ? [] : each.value.prefix_list_ids
+  self                     = each.value.self
   source_security_group_id = each.value.source_security_group_id
 
   depends_on = [aws_security_group.cbd, aws_security_group.default]
@@ -239,11 +163,5 @@ resource "aws_security_group_rule" "keyed_source_security_group_id" {
 }
 
 locals {
-  rules_terraform_ids = concat(
-    values(aws_security_group_rule.keyed_cidr_blocks)[*].id,
-    values(aws_security_group_rule.keyed_ipv6_cidr_blocks)[*].id,
-    values(aws_security_group_rule.keyed_prefix_list_ids)[*].id,
-    values(aws_security_group_rule.keyed_self)[*].id,
-    values(aws_security_group_rule.keyed_source_security_group_id)[*].id
-  )
+  rules_terraform_ids = values(aws_security_group_rule.keyed).*.id
 }

--- a/main.tf
+++ b/main.tf
@@ -139,7 +139,7 @@ resource "aws_security_group" "cbd" {
 }
 
 resource "aws_security_group_rule" "keyed_cidr_blocks" {
-  for_each = { for r in local.all_resource_rules : r.key => r if try(r.cidr_blocks, null) != null }
+  for_each = { for r in local.all_resource_rules : r.key => r if try(length(r.cidr_blocks), 0) > 0 }
 
   security_group_id = local.security_group_id
 
@@ -159,7 +159,7 @@ resource "aws_security_group_rule" "keyed_cidr_blocks" {
 }
 
 resource "aws_security_group_rule" "keyed_ipv6_cidr_blocks" {
-  for_each = { for r in local.all_resource_rules : r.key => r if try(r.ipv6_cidr_blocks, null) != null }
+  for_each = { for r in local.all_resource_rules : r.key => r if try(length(r.ipv6_cidr_blocks), 0) > 0 }
 
   security_group_id = local.security_group_id
 
@@ -179,7 +179,7 @@ resource "aws_security_group_rule" "keyed_ipv6_cidr_blocks" {
 }
 
 resource "aws_security_group_rule" "keyed_prefix_list_ids" {
-  for_each = { for r in local.all_resource_rules : r.key => r if try(r.prefix_list_ids, null) != null }
+  for_each = { for r in local.all_resource_rules : r.key => r if try(length(r.prefix_list_ids), 0) > 0 }
 
   security_group_id = local.security_group_id
 
@@ -219,7 +219,7 @@ resource "aws_security_group_rule" "keyed_self" {
 }
 
 resource "aws_security_group_rule" "keyed_source_security_group_id" {
-  for_each = { for r in local.all_resource_rules : r.key => r if try(r.source_security_group_id, null) != null }
+  for_each = { for r in local.all_resource_rules : r.key => r if try(length(r.source_security_group_id), 0) > 0 }
 
   security_group_id = local.security_group_id
 

--- a/main.tf
+++ b/main.tf
@@ -139,7 +139,7 @@ resource "aws_security_group" "cbd" {
 }
 
 resource "aws_security_group_rule" "keyed_cidr_blocks" {
-  for_each = { for k, v in local.keyed_resource_rules : k => v if try(v.cidr_blocks, null) != null }
+  for_each = { for r in local.all_resource_rules : r.key => r if try(r.cidr_blocks, null) != null }
 
   security_group_id = local.security_group_id
 
@@ -159,7 +159,7 @@ resource "aws_security_group_rule" "keyed_cidr_blocks" {
 }
 
 resource "aws_security_group_rule" "keyed_ipv6_cidr_blocks" {
-  for_each = { for k, v in local.keyed_resource_rules : k => v if try(v.ipv6_cidr_blocks, null) != null }
+  for_each = { for r in local.all_resource_rules : r.key => r if try(r.ipv6_cidr_blocks, null) != null }
 
   security_group_id = local.security_group_id
 
@@ -179,7 +179,7 @@ resource "aws_security_group_rule" "keyed_ipv6_cidr_blocks" {
 }
 
 resource "aws_security_group_rule" "keyed_prefix_list_ids" {
-  for_each = { for k, v in local.keyed_resource_rules : k => v if try(v.prefix_list_ids, null) != null }
+  for_each = { for r in local.all_resource_rules : r.key => r if try(r.prefix_list_ids, null) != null }
 
   security_group_id = local.security_group_id
 
@@ -199,7 +199,7 @@ resource "aws_security_group_rule" "keyed_prefix_list_ids" {
 }
 
 resource "aws_security_group_rule" "keyed_self" {
-  for_each = { for k, v in local.keyed_resource_rules : k => v if try(v.self, false) == true }
+  for_each = { for r in local.all_resource_rules : r.key => r if try(r.self, false) == true }
 
   security_group_id = local.security_group_id
 
@@ -219,7 +219,7 @@ resource "aws_security_group_rule" "keyed_self" {
 }
 
 resource "aws_security_group_rule" "keyed_source_security_group_id" {
-  for_each = { for k, v in local.keyed_resource_rules : k => v if try(v.source_security_group_id, null) != null }
+  for_each = { for r in local.all_resource_rules : r.key => r if try(r.source_security_group_id, null) != null }
 
   security_group_id = local.security_group_id
 

--- a/main.tf
+++ b/main.tf
@@ -146,8 +146,8 @@ resource "aws_security_group_rule" "keyed" {
   to_port          = each.value.to_port
   protocol         = each.value.protocol
   description      = each.value.description
-  cidr_blocks      = length(each.value.cidr_blocks) == 0 ? null : each.value.cidr_blocks
-  ipv6_cidr_blocks = length(each.value.ipv6_cidr_blocks) == 0 ? null : each.value.ipv6_cidr_blocks
+  cidr_blocks      = length(each.value.cidr_blocks) == 0 ? [] : each.value.cidr_blocks
+  ipv6_cidr_blocks = length(each.value.ipv6_cidr_blocks) == 0 ? [] : each.value.ipv6_cidr_blocks
   prefix_list_ids  = length(each.value.prefix_list_ids) == 0 ? [] : each.value.prefix_list_ids
   self             = each.value.self
 

--- a/normalize.tf
+++ b/normalize.tf
@@ -156,4 +156,10 @@ locals {
 
   all_resource_rules   = concat(local.norm_rules, local.self_rules, local.sg_exploded_rules, local.other_rules, local.extra_rules)
   keyed_resource_rules = { for r in local.all_resource_rules : r.key => r }
+
+  keyed_resource_rules_cidr_blocks              = { for r in local.all_resource_rules : r.key => r if try(length(r.cidr_blocks), 0) > 0 }
+  keyed_resource_rules_ipv6_cidr_blocks         = { for r in local.all_resource_rules : r.key => r if try(length(r.ipv6_cidr_blocks), 0) > 0 }
+  keyed_resource_rules_prefix_list_ids          = { for r in local.all_resource_rules : r.key => r if try(length(r.prefix_list_ids), 0) > 0 }
+  keyed_resource_rules_self                     = { for r in local.all_resource_rules : r.key => r if try(r.self, false) == true }
+  keyed_resource_rules_source_security_group_id = { for r in local.all_resource_rules : r.key => r if try(length(r.source_security_group_id), 0) > 0 }
 }

--- a/normalize.tf
+++ b/normalize.tf
@@ -157,5 +157,3 @@ locals {
   all_resource_rules   = concat(local.norm_rules, local.self_rules, local.sg_exploded_rules, local.other_rules, local.extra_rules)
   keyed_resource_rules = { for r in local.all_resource_rules : r.key => r }
 }
-
-

--- a/normalize.tf
+++ b/normalize.tf
@@ -156,10 +156,4 @@ locals {
 
   all_resource_rules   = concat(local.norm_rules, local.self_rules, local.sg_exploded_rules, local.other_rules, local.extra_rules)
   keyed_resource_rules = { for r in local.all_resource_rules : r.key => r }
-
-  keyed_resource_rules_cidr_blocks              = { for r in local.all_resource_rules : r.key => r if try(length(r.cidr_blocks), 0) > 0 }
-  keyed_resource_rules_ipv6_cidr_blocks         = { for r in local.all_resource_rules : r.key => r if try(length(r.ipv6_cidr_blocks), 0) > 0 }
-  keyed_resource_rules_prefix_list_ids          = { for r in local.all_resource_rules : r.key => r if try(length(r.prefix_list_ids), 0) > 0 }
-  keyed_resource_rules_self                     = { for r in local.all_resource_rules : r.key => r if try(r.self, false) == true }
-  keyed_resource_rules_source_security_group_id = { for r in local.all_resource_rules : r.key => r if try(length(r.source_security_group_id), 0) > 0 }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -15,5 +15,5 @@ output "name" {
 
 output "rules_terraform_ids" {
   description = "List of Terraform IDs of created `security_group_rule` resources, primarily provided to enable `depends_on`"
-  value       = local.rules_terraform_ids
+  value       = values(aws_security_group_rule.keyed).*.id
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,3 @@
-
 output "id" {
   description = "The created or target Security Group ID"
   value       = local.security_group_id
@@ -16,5 +15,5 @@ output "name" {
 
 output "rules_terraform_ids" {
   description = "List of Terraform IDs of created `security_group_rule` resources, primarily provided to enable `depends_on`"
-  value       = values(aws_security_group_rule.keyed).*.id
+  value       = local.rules_terraform_ids
 }


### PR DESCRIPTION
## what
* Rename the exported `security_group_inputs.tf` file to `security-group-inputs.tf`
* Update GitHub workflows and LICENSE

## why
* Our naming convention is to use `kebab-case` for all files. Having a file in `snake_case` (after adding it to a repo) together with all the other files in `kebab-case` in the same repo does not look correct
* Keep up to date
